### PR TITLE
Lootr support: convert single instance of member to static method.

### DIFF
--- a/src/main/java/svenhjol/charm/module/MineshaftImprovements.java
+++ b/src/main/java/svenhjol/charm/module/MineshaftImprovements.java
@@ -6,6 +6,7 @@ import net.minecraft.block.LanternBlock;
 import net.minecraft.block.SlabBlock;
 import net.minecraft.loot.LootTables;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.LockableLootTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
@@ -187,11 +188,7 @@ public class MineshaftImprovements extends CharmModule {
 
                     world.setBlockState(blockpos, state, 2);
 
-                    TileEntity tileEntity = world.getTileEntity(blockpos);
-                    if (tileEntity instanceof CrateTileEntity) {
-                        ((CrateTileEntity) tileEntity).setLootTable(loot, rand.nextLong());
-                        tileEntity.write(new CompoundNBT());
-                    }
+                    LockableLootTileEntity.setLootTable(world, rand, blockpos, loot);
                 }
             }
         }


### PR DESCRIPTION
LockableLootTileEntity's static setLootTable method is the only point
that I can inject to modify the world while it's being generated;
hooking into the member setLootTable generally results in the world
either being null or being the server world -- and modifying the world
at the point results in concurrent modification issues.

All other instances of setLootTable are just being used to initialise a
tile and then write the information to a processor tag, which should be
automatically handled by Lootr's own processor.

Finally, this will only affect crates which Lootr supports. Thus, this
commit isn't strictly necessary, but the functionality ends up being
identical as the check in the static method is the same as what was
replaced.